### PR TITLE
Use lib-js-util-base lib instead of lodash

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+save-exact=true

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const zlib = require('zlib')
 const archiver = require('archiver')
-const { pick } = require('lodash')
+const { pick } = require('lib-js-util-base')
 const async = require('async')
 const Base = require('bfx-facs-base')
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "archiver": "3.1.1",
     "async": "3.2.4",
     "bfx-facs-base": "git+https://github.com:bitfinexcom/bfx-facs-base.git",
-    "lodash": "^4.17.10"
+    "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git"
   },
   "devDependencies": {
     "standard": "^12.0.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "archiver": "3.1.1",
-    "async": "^2.6.1",
+    "async": "3.2.4",
     "bfx-facs-base": "git+https://github.com:bitfinexcom/bfx-facs-base.git",
     "lodash": "^4.17.10"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/bitfinexcom/bfx-facs-deflate/issues"
   },
   "dependencies": {
-    "archiver": "^3.0.0",
+    "archiver": "3.1.1",
     "async": "^2.6.1",
     "bfx-facs-base": "git+https://github.com:bitfinexcom/bfx-facs-base.git",
     "lodash": "^4.17.10"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git"
   },
   "devDependencies": {
-    "standard": "^12.0.1"
+    "standard": "17.1.0"
   },
   "scripts": {
     "test": "standard"


### PR DESCRIPTION
This PR adds ability to use [lib-js-util-base](https://github.com/bitfinexcom/lib-js-util-base) lib instead of the `lodash`

---

Base changes:
- uses `lib-js-util-base` lib instead of `lodash`
- adds `.npmrc` config to not keep package-lock
- hardcores `archiver` version
- bumps `async` version to fix vulnerability https://github.com/advisories/GHSA-fwr7-v2mv-hh25
- bumps `standard` version
